### PR TITLE
hot-fix in index of for in cryptoboard view

### DIFF
--- a/src/views/CryptoBoard.vue
+++ b/src/views/CryptoBoard.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="board">
-    <div class="card-block" v-for="(value, index) in currencies" :key="index">
+    <!-- it is not recommended to use the index in "v-for" for iteration because it restarts when the component is rendered causing the component positions to overlap.  -->
+    <div class="card-block" v-for="value in currencies" :key="`currency-${value.symbol}`">
       <CurrencyCard :ticker="tickers[value.symbol] || {}" :info="value"></CurrencyCard>
     </div>
   </div>


### PR DESCRIPTION
it is not recommended to use the index in "v-for" for iteration because it restarts when the component is rendered causing the component positions to overlap. 